### PR TITLE
Ensure result queue is populated before a job is queued

### DIFF
--- a/alopekis/utils.py
+++ b/alopekis/utils.py
@@ -63,11 +63,10 @@ def queue_month(
         logger.info(f"No count for {year}-{month} provided, querying OpenSearch")
         count = get_month_count(year, month, logger)
 
-    work_queue.put({"year": int(year), "month": int(month), "count": count})
     results_queue.put(
         {"year": int(year), "month": int(month), "count": count, "status": "expected"}
     )
-
+    work_queue.put({"year": int(year), "month": int(month), "count": count})
 
 def update_status(status: str) -> None:
     """~Write status to STATUS.json in the S3 bucket"""


### PR DESCRIPTION
## Purpose
Make sure that the results queue is populated with the expected result before the job is queued, to prevent the job finishing and reporting to the results queue before the expected count is known.

closes: #37 
## Approach
<!--- _How does this change address the problem?_ -->

#### Open Questions and Pre-Merge TODOs
<!--- - [ ] Use github checklists. When solved, check the box and explain the answer. -->

## Learning
<!--- _Describe the research stage_ -->

<!--- _Links to blog posts, patterns, libraries or addons used to solve this problem_ -->


## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
